### PR TITLE
Update polymer-build to v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-jsonmin": "^1.1.0",
     "gulp-uglify": "^2.1.0",
     "merge-stream": "^1.0.0",
-    "polymer-build": "^0.9.0"
+    "polymer-build": "^1.2.0"
   },
   "scripts": {
     "lint": "eslint . --ext js,html --ignore-path .gitignore",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,12 +68,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/split@^0.3.28":
-  version "0.3.28"
-  resolved "https://registry.yarnpkg.com/@types/split/-/split-0.3.28.tgz#66d0361dbd9715b093d6b27a4c9985daadccc9ec"
-  dependencies:
-    "@types/node" "*"
-
 "@types/vinyl-fs@0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/vinyl-fs/-/vinyl-fs-0.0.28.tgz#4663017bc802c6570eae4f3409fd5cabf97cbfde"
@@ -82,9 +76,9 @@
     "@types/node" "*"
     "@types/vinyl" "*"
 
-"@types/vinyl@*", "@types/vinyl@^1.1.29":
-  version "1.2.30"
-  resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-1.2.30.tgz#9115c0c45c40c575738906be9fb4df6f5b9e5013"
+"@types/vinyl@*", "@types/vinyl@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.0.tgz#fd213bf7f4136dde21fe1895500b12c186f8c268"
   dependencies:
     "@types/node" "*"
 
@@ -899,7 +893,7 @@ dom-urls@^1.1.0:
   dependencies:
     urijs "^1.16.1"
 
-dom5@^2.0.0, dom5@^2.0.1, dom5@^2.1.0:
+dom5@^2.1.0, dom5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dom5/-/dom5-2.2.0.tgz#ff2358018057e8be3f30eabbc1edff10086114b9"
   dependencies:
@@ -3077,9 +3071,9 @@ plylog@^0.5.0:
     "@types/winston" "^2.2.0"
     winston "^2.2.0"
 
-polymer-analyzer@2.0.0-alpha.34:
-  version "2.0.0-alpha.34"
-  resolved "https://registry.yarnpkg.com/polymer-analyzer/-/polymer-analyzer-2.0.0-alpha.34.tgz#6e95ea37247c036c53d1ef6c25f12a2763984eab"
+polymer-analyzer@2.0.0-alpha.40:
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/polymer-analyzer/-/polymer-analyzer-2.0.0-alpha.40.tgz#a731df6cee1b3ae364bd94942f10d7b3dbbc8602"
   dependencies:
     "@types/chai-subset" "^1.3.0"
     "@types/chalk" "^0.4.30"
@@ -3090,7 +3084,6 @@ polymer-analyzer@2.0.0-alpha.34:
     "@types/estree" "^0.0.34"
     "@types/node" "^6.0.0"
     "@types/parse5" "^2.2.34"
-    "@types/split" "^0.3.28"
     chalk "^1.1.3"
     clone "^2.0.0"
     cssbeautify "^0.3.1"
@@ -3102,44 +3095,43 @@ polymer-analyzer@2.0.0-alpha.34:
     jsonschema "^1.1.0"
     parse5 "^2.2.1"
     shady-css-parser "0.0.8"
-    split "^1.0.0"
     strip-indent "^2.0.0"
     typescript "^2.2.0"
 
-polymer-build@^0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-0.9.1.tgz#e3971aec554d42edd187e7284fc10d63c669e44e"
+polymer-build@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/polymer-build/-/polymer-build-1.2.0.tgz#e3dddc7a9348a90d4d2191873a5475a7f216929a"
   dependencies:
     "@types/node" "^4.2.3"
     "@types/parse5" "^2.2.32"
-    "@types/vinyl" "^1.1.29"
+    "@types/vinyl" "^2.0.0"
     "@types/vinyl-fs" "0.0.28"
-    dom5 "^2.0.1"
+    dom5 "^2.2.0"
     multipipe "^1.0.2"
     parse5 "^2.2.2"
     plylog "^0.5.0"
-    polymer-analyzer "2.0.0-alpha.34"
-    polymer-bundler "2.0.0-pre.11"
+    polymer-analyzer "2.0.0-alpha.40"
+    polymer-bundler "2.0.0-pre.13"
     polymer-project-config "^2.0.0"
     sw-precache "^4.2.0"
     vinyl "^1.1.1"
     vinyl-fs "^2.4.3"
 
-polymer-bundler@2.0.0-pre.11:
-  version "2.0.0-pre.11"
-  resolved "https://registry.yarnpkg.com/polymer-bundler/-/polymer-bundler-2.0.0-pre.11.tgz#c08467d8308502841d1e33e0232c6fc3a9f81b28"
+polymer-bundler@2.0.0-pre.13:
+  version "2.0.0-pre.13"
+  resolved "https://registry.yarnpkg.com/polymer-bundler/-/polymer-bundler-2.0.0-pre.13.tgz#30c782041d49df30f3bac3f5232b0dd8924e4b9b"
   dependencies:
     clone "^2.1.0"
     command-line-args "^3.0.1"
     command-line-usage "^3.0.3"
-    dom5 "^2.0.0"
+    dom5 "^2.2.0"
     es6-promise "^2.1.0"
     espree "^3.4.0"
     mkdirp "^0.5.1"
     nopt "^3.0.1"
     parse5 "^2.2.2"
     path-posix "^1.0.0"
-    polymer-analyzer "2.0.0-alpha.34"
+    polymer-analyzer "2.0.0-alpha.40"
     source-map "^0.5.6"
 
 polymer-project-config@^2.0.0:
@@ -3529,12 +3521,6 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-split@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
-  dependencies:
-    through "2"
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -3821,7 +3807,7 @@ through2@^2.0.0, through2@^2.0.1, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, through@^2.3.6:
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
- From: 1,672,137 bytes (1.8 MB on disk) for 98 items
- To: 1,245,745 bytes (1.3 MB on disk) for 31 items